### PR TITLE
Attempt to fix report size delta subjob

### DIFF
--- a/.github/workflows/arduino-compile.yml
+++ b/.github/workflows/arduino-compile.yml
@@ -16,6 +16,10 @@ on:
   workflow_dispatch:
   repository_dispatch:
 
+env:
+  SKETCHES_REPORTS_PATH: sketches-reports
+  SKETCHES_REPORTS_NAME: esp32
+
 jobs:
   build:
     name: Arduino Uno
@@ -29,7 +33,6 @@ jobs:
         - name: ArduinoJson
         - name: WiFiEsp
         - name: TinyGSM
-      SKETCHES_REPORTS_PATH: sketches-reports
 
     steps:
       - uses: actions/checkout@v3
@@ -45,7 +48,7 @@ jobs:
             - examples/0002-arduino_rpc/0002-arduino_rpc.ino
             - examples/0004-arduino-sim900_send_telemetry/0004-arduino-sim900_send_telemetry.ino
             - examples/0005-arduino-sim900_send_telemetry_http/0005-arduino-sim900_send_telemetry_http.ino
-          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}
           enable-warnings-report: 'true'
 
       - name: Save memory usage change report as artifact
@@ -53,8 +56,8 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
-          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_NAME }}
+          path: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}
 
   report:
     needs: build  # Wait for the build job to finish to get the data for the report
@@ -65,9 +68,9 @@ jobs:
       - name: Download sketches reports artifact
         uses: actions/download-artifact@v2
         with:
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
-          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_NAME }}
+          path: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}
 
       - uses: arduino/report-size-deltas@v1
         with:
-          sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}
+          sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}

--- a/.github/workflows/esp32-compile.yml
+++ b/.github/workflows/esp32-compile.yml
@@ -28,6 +28,7 @@ jobs:
         - name: ArduinoHttpClient
         - name: ArduinoJson
       SKETCHES_REPORTS_PATH: sketches-reports
+      SKETCHES_REPORTS_NAME: arduino
 
     strategy:
       matrix:
@@ -76,8 +77,8 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
-          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_NAME }}
+          path: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}
 
   report:
     needs: build  # Wait for the build job to finish to get the data for the report
@@ -88,9 +89,9 @@ jobs:
       - name: Download sketches reports artifact
         uses: actions/download-artifact@v2
         with:
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
-          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_NAME }}
+          path: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}
 
       - uses: arduino/report-size-deltas@v1
         with:
-          sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}
+          sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}

--- a/.github/workflows/esp32-compile.yml
+++ b/.github/workflows/esp32-compile.yml
@@ -16,6 +16,10 @@ on:
   workflow_dispatch:
   repository_dispatch:
 
+env:
+  SKETCHES_REPORTS_PATH: sketches-reports
+  SKETCHES_REPORTS_NAME: esp32
+
 jobs:
   build:
     name: ${{ matrix.board.fqbn }}
@@ -27,8 +31,6 @@ jobs:
         - name: TBPubSubClient
         - name: ArduinoHttpClient
         - name: ArduinoJson
-      SKETCHES_REPORTS_PATH: sketches-reports
-      SKETCHES_REPORTS_NAME: arduino
 
     strategy:
       matrix:
@@ -84,9 +86,6 @@ jobs:
     needs: build  # Wait for the build job to finish to get the data for the report
     if: github.event_name == 'pull_request' # Only run the job when the workflow is triggered by a pull request
     runs-on: ubuntu-latest
-    env:
-      SKETCHES_REPORTS_PATH: sketches-reports
-      SKETCHES_REPORTS_NAME: arduino
     steps:
       # This step is needed to get the size data produced by the build jobs
       - name: Download sketches reports artifact

--- a/.github/workflows/esp32-compile.yml
+++ b/.github/workflows/esp32-compile.yml
@@ -69,7 +69,7 @@ jobs:
             - examples/0011-esp8266_esp32_subscribe_OTA_MQTT/0011-esp8266_esp32_subscribe_OTA_MQTT.ino
             - examples/0012-esp8266_esp32_request_shared_attribute/0012-esp8266_esp32_request_shared_attribute.ino
             - examples/0013-esp8266_esp32_request_rpc/0013-esp8266_esp32_request_rpc.ino
-          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}
           enable-warnings-report: 'true'
 
       - name: Save memory usage change report as artifact

--- a/.github/workflows/esp32-compile.yml
+++ b/.github/workflows/esp32-compile.yml
@@ -84,6 +84,9 @@ jobs:
     needs: build  # Wait for the build job to finish to get the data for the report
     if: github.event_name == 'pull_request' # Only run the job when the workflow is triggered by a pull request
     runs-on: ubuntu-latest
+    env:
+      SKETCHES_REPORTS_PATH: sketches-reports
+      SKETCHES_REPORTS_NAME: arduino
     steps:
       # This step is needed to get the size data produced by the build jobs
       - name: Download sketches reports artifact

--- a/.github/workflows/esp8266-compile.yml
+++ b/.github/workflows/esp8266-compile.yml
@@ -16,6 +16,10 @@ on:
   workflow_dispatch:
   repository_dispatch:
 
+env:
+  SKETCHES_REPORTS_PATH: sketches-reports
+  SKETCHES_REPORTS_NAME: esp8266
+
 jobs:
   build:
     name: ${{ matrix.board.fqbn }}
@@ -28,7 +32,6 @@ jobs:
         - name: ArduinoHttpClient
         - name: ArduinoJson
         - name: Seeed_Arduino_mbedtls
-      SKETCHES_REPORTS_PATH: sketches-reports
 
     strategy:
       matrix:
@@ -66,7 +69,7 @@ jobs:
             - examples/0011-esp8266_esp32_subscribe_OTA_MQTT/0011-esp8266_esp32_subscribe_OTA_MQTT.ino
             - examples/0012-esp8266_esp32_request_shared_attribute/0012-esp8266_esp32_request_shared_attribute.ino
             - examples/0013-esp8266_esp32_request_rpc/0013-esp8266_esp32_request_rpc.ino
-          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}
           enable-warnings-report: 'true'
 
       - name: Save memory usage change report as artifact
@@ -74,8 +77,8 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
-          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_NAME }}
+          path: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}
 
   report:
     needs: build  # Wait for the build job to finish to get the data for the report
@@ -86,9 +89,9 @@ jobs:
       - name: Download sketches reports artifact
         uses: actions/download-artifact@v2
         with:
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
-          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_NAME }}
+          path: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}
 
       - uses: arduino/report-size-deltas@v1
         with:
-          sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}
+          sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}


### PR DESCRIPTION
Attempt to fix the [Report Size Deltas](https://github.com/arduino/report-size-deltas) workflow, so it will comment on this pull request with the changed memory usage gotten by the previous [Compile Sketches](https://github.com/arduino/compile-sketches) workflow.