### PR TITLE
Update Compile Action Paths for Version-Specific Workflows

### DIFF
--- a/.github/workflows/espidf-compile-v4.4.yml
+++ b/.github/workflows/espidf-compile-v4.4.yml
@@ -3,12 +3,12 @@ name: Compile ESP-IDF Sketches for v4.4
 on:
   pull_request:
     paths:
-      - ".github/workflows/espidf-compile.yml"
+      - ".github/workflows/espidf-compile-v*.yml"
       - "examples/**"
       - "src/**"
   push:
     paths:
-      - ".github/workflows/espidf-compile.yml"
+      - ".github/workflows/espidf-compile-v*.yml"
       - "examples/**"
       - "src/**"
   workflow_dispatch:

--- a/.github/workflows/espidf-compile-v5.1.yml
+++ b/.github/workflows/espidf-compile-v5.1.yml
@@ -3,12 +3,12 @@ name: Compile ESP-IDF Sketches for v5.1
 on:
   pull_request:
     paths:
-      - ".github/workflows/espidf-compile.yml"
+      - ".github/workflows/espidf-compile-v*.yml"
       - "examples/**"
       - "src/**"
   push:
     paths:
-      - ".github/workflows/espidf-compile.yml"
+      - ".github/workflows/espidf-compile-v*.yml"
       - "examples/**"
       - "src/**"
   workflow_dispatch:


### PR DESCRIPTION
Integrate #185 into current pull request

This commit revises the GitHub Action workflow triggers for the ESP-IDF compilation process. Previously, the action was configured to trigger only for changes to `espidf-compile.yml`. However, the workflows have evolved to use version-specific filenames, namely `espidf-compile-v5.1.yml` and `espidf-compile-v4.4.yml`.

To accommodate these changes and ensure that the CI processes are accurately triggered, the paths in the workflow trigger settings have been updated. The new path pattern `.github/workflows/espidf-compile-v*.yml` is introduced to capture any future version-specific workflow files as well. This update ensures that any modifications to these version-specific workflows will properly initiate the corresponding GitHub Actions.

This change enhances the maintainability of the CI/CD pipeline by aligning the workflow triggers with the current file naming conventions and preparing for potential future expansions.

Affected areas:
- Pull Request events
- Push events